### PR TITLE
 Moved warning above submit button instead of next to it.

### DIFF
--- a/static/riotjs/wizard/define_homework.tag
+++ b/static/riotjs/wizard/define_homework.tag
@@ -350,12 +350,10 @@
         </div>
 
         <div class="ui divider"></div>
-
+            <div class="ui error message"></div>
             <div class="button-container">
                 <span><a onclick="{submit_form}" class="ui green button">Submit</a>
                 <a onclick="{cancel_button}" class="ui red button">Cancel</a></span>
-            <div class="ui error message"></div>
-
         </div>
     </form>
 


### PR DESCRIPTION
@ mention of reviewers
@gibsonbailey 

# A brief description of the purpose of the changes contained in this PR.
Move the validation warning from to the right of the submit button to above it.


# Known issues to be addressed in a separate PR
...


# A checklist for hand testing
- [ ] On define homework add a custom question without a type to get an error and observe the new position above the submit and cancel buttons.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
